### PR TITLE
[pysha3 installation bug] Embedding ecrecover_to_pub() | Removing ethereum package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 # Additional requirements go here
-ethereum==2.3.2
-rlp<=2.0.0
+coincurve
+rlp>=2.0.0
 eth_utils>=1.0.3
 Django>=2.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'web3auth',
     ],
     include_package_data=True,
-    install_requires=['ethereum==2.3.2', 'rlp<=2.0.0', 'eth_utils>=1.0.3', 'Django>=2.0'],
+    install_requires=['coincurve>=18.0.0', 'rlp>=2.0.0', 'eth_utils>=1.0.3', 'Django>=2.0'],
     license="MIT",
     zip_safe=False,
     keywords='django-web3-auth',

--- a/web3auth/utils.py
+++ b/web3auth/utils.py
@@ -1,10 +1,68 @@
 import sha3
-import ethereum
 from eth_utils import is_hex_address
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from ethereum.utils import ecrecover_to_pub
+from py_ecc.secp256k1 import ecdsa_raw_recover
+from rlp.utils import ALL_BYTES
+try:
+    import coincurve
+except ImportError:
+    import warnings
+    warnings.warn('could not import coincurve', ImportWarning)
+    coincurve = None
 
+def encode_int32(v):
+    return v.to_bytes(32, byteorder='big')
+
+def bytearray_to_bytestr(value):
+    return bytes(value)
+
+def int_to_32bytearray(i):
+    o = [0] * 32
+    for x in range(32):
+        o[31 - x] = i & 0xff
+        i >>= 8
+    return o
+
+def ascii_chr(n):
+    return ALL_BYTES[n]
+
+def zpad(x, l):
+    """ Left zero pad value `x` at least to length `l`.
+
+    >>> zpad('', 1)
+    '\x00'
+    >>> zpad('\xca\xfe', 4)
+    '\x00\x00\xca\xfe'
+    >>> zpad('\xff', 1)
+    '\xff'
+    >>> zpad('\xca\xfe', 2)
+    '\xca\xfe'
+    """
+    return b'\x00' * max(0, l - len(x)) + x
+
+
+def ecrecover_to_pub(rawhash, v, r, s):
+    if coincurve and hasattr(coincurve, "PublicKey"):
+        try:
+            pk = coincurve.PublicKey.from_signature_and_message(
+                zpad(bytearray_to_bytestr(int_to_32bytearray(r)), 32) + zpad(bytearray_to_bytestr(int_to_32bytearray(s)), 32) +
+                ascii_chr(v - 27),
+                rawhash,
+                hasher=None,
+            )
+            pub = pk.format(compressed=False)[1:]
+        except BaseException:
+            pub = b"\x00" * 64
+    else:
+        result = ecdsa_raw_recover(rawhash, (v, r, s))
+        if result:
+            x, y = result
+            pub = encode_int32(x) + encode_int32(y)
+        else:
+            raise ValueError('Invalid VRS')
+    assert len(pub) == 64
+    return pub
 
 def sig_to_vrs(sig):
     #    sig_bytes = bytes.fromhex(sig[2:])


### PR DESCRIPTION
Removing `ethereum` package requirement due to deprecation...

`pip` was currently unable to download `django-web3-auth` due to `pysha3` missing headers, required to install deprecated `ethereum` library, see [This bug report](https://github.com/tiran/pysha3/issues/15)

Since I really didn't found a replacement with the updated `py-evm` library docs...

I've basically copied from the `ethereum.utils` module the only function that impose the requirement-> `ecrecover_to_pub` , along with the utility functions needed.

Added also `coincurve` requirement, needed for those utilities. And imposed a version greater or equals than 2.0.0 for `rlp`